### PR TITLE
Fixup failing unit test for tests.unit.states.test_boto_asg.py file

### DIFF
--- a/salt/states/boto_asg.py
+++ b/salt/states/boto_asg.py
@@ -201,7 +201,6 @@ import copy
 # Import Salt libs
 import salt.utils.dictupdate as dictupdate
 import salt.ext.six as six
-from salt.ext.six.moves import zip  # pylint: disable=import-error,redefined-builtin
 from salt.exceptions import SaltInvocationError
 
 log = logging.getLogger(__name__)


### PR DESCRIPTION
With the changes proposed in https://github.com/saltstack/salt/pull/39977, the mock values need to be updated to account for the new calls to `salt.utils.boto3.ordered`. This PR updates the the mocked values to account for these calls using MagicMock side_effects.

Also fixed a relevant pylint error.

cc @tkwilliams 